### PR TITLE
Bugfixes for running on Windows

### DIFF
--- a/nmm.pl
+++ b/nmm.pl
@@ -97,7 +97,7 @@ my $pidfile = File::Pid->new({
    file => $conf->{pid_file}
 });
 
-if ( $pidfile->running ) {
+if ( -f $conf->{pid_file} and $pidfile->running ) {
    die "Already running";
 }
 

--- a/nmm.pl
+++ b/nmm.pl
@@ -438,7 +438,7 @@ sub get_da_scrape {
       }
    }
 
-   return $fullview->attrs( 'src' );
+   return $fullview->attr( 'src' );
 }
 
 #


### PR DESCRIPTION
- Standing File-Pid bug [#18960](https://rt.cpan.org/Public/Bug/Display.html?id=18960) is not 
  patched by everyone (including some win packagings), so here's a simple work-around.
- The `attrs` method of Mojo::DOM was [deprecated](https://metacpan.org/changes/distribution/Mojolicious#L1176), then [removed](https://metacpan.org/changes/distribution/Mojolicious#L1024) by v4.50 in favor of `attr`.
